### PR TITLE
Implement search_notion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ $ python scripts/send_test_request.py
 ```
 The script reads `SERVER_URL` and `API_KEY` from your environment (falls back to localhost/test-key).
 
+### Searching Notion
+```bash
+curl -X POST http://localhost:8000/search-notion \
+  -H "Authorization: Bearer test-key" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "meeting notes"}'
+```
+
 ---
 
 ## 🛠  Extending the Agent

--- a/Voice2NotionServer/main.py
+++ b/Voice2NotionServer/main.py
@@ -65,6 +65,9 @@ class TextInput(BaseModel):
 class NotionInput(BaseModel):
     prompt: str
 
+class SearchInput(BaseModel):
+    query: str
+
 @app.post("/add-to-notion")
 @limiter.limit("10/minute")
 async def add_to_notion(request: Request, input: NotionInput, api_key: str = Depends(get_api_key)):
@@ -76,6 +79,15 @@ async def add_to_notion(request: Request, input: NotionInput, api_key: str = Dep
     result = await chain.ainvoke(state)
 
     return {"message": "Request processed successfully", "result": result}
+
+
+@app.post("/search-notion")
+@limiter.limit("10/minute")
+async def search_notion(request: Request, input: SearchInput, api_key: str = Depends(get_api_key)):
+    """Proxy a search query to the Notion search API"""
+    logger.info(f"Searching Notion for: {input.query}")
+    resp = await notion.search(query=input.query)
+    return resp
 
 @app.get("/health")
 @limiter.limit("30/minute")


### PR DESCRIPTION
## Summary
- expose new `/search-notion` endpoint that proxies queries to the Notion search API
- document the endpoint in the README

## Testing
- `pytest -q` *(fails: command not found)*